### PR TITLE
Parse out prefix if passed into input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
 
 outputs:
   REF_WITHOUT_PREFIX:
-    description: 'References without a prefix if present'
+    description: 'Reference without a prefix if present'
     value: ${{ steps.determine-ref.outputs.REF_WITHOUT_PREFIX }}
   REF_EXISTS:
     description: 'Flag indicating whether the provided reference exists.  true|false'

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
     default: 'true'
 
 outputs:
+  REF_WITHOUT_PREFIX:
+    description: 'References without a prefix if present'
+    value: ${{ steps.remove-ref-prefix.outputs.result }}
   REF_EXISTS:
     description: 'Flag indicating whether the provided reference exists.  true|false'
     value: ${{ steps.determine-ref.outputs.REF_EXISTS }}
@@ -22,12 +25,19 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    
+    # Removes any leading paths if present i.e. refs/tags/v2.1.0 -> v2.1.0
+    - id: remove-ref-prefix
+      env: 
+        GITHUB_REF: ${{ inputs.branch-tag-sha }}
+      run: echo "##[set-output name=result;]${GITHUB_REF##*/}"
+      
     - id: determine-ref
       shell: bash
       run: |
         echo "checking ref ${{ inputs.branch-tag-sha }}..."
         ref="${{ inputs.branch-tag-sha }}"
-        refWithPrefix="refs/heads${{ inputs.branch-tag-sha }}"
+        refWithPrefix="refs/heads${{ steps.remove-ref-prefix.outputs.result }}"
         
         echo "::set-output name=REF_EXISTS::false"
         echo "::set-output name=REF_TYPE::unknown"

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 outputs:
   REF_WITHOUT_PREFIX:
     description: 'References without a prefix if present'
-    value: ${{ steps.remove-ref-prefix.outputs.result }}
+    value: ${{ steps.determine-ref.outputs.REF_WITHOUT_PREFIX }}
   REF_EXISTS:
     description: 'Flag indicating whether the provided reference exists.  true|false'
     value: ${{ steps.determine-ref.outputs.REF_EXISTS }}
@@ -25,21 +25,16 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    
-    # Removes any leading paths if present i.e. refs/tags/v2.1.0 -> v2.1.0
-    - id: remove-ref-prefix
-      env: 
-        GITHUB_REF: ${{ inputs.branch-tag-sha }}
-      run: echo "::set-output name=result::${GITHUB_REF##*/}"  
-      #run: echo "##[set-output name=result;]${GITHUB_REF##*/}"
-      
     - id: determine-ref
       shell: bash
+      env: 
+        GITHUB_REF: "${{ inputs.branch-tag-sha }}"
       run: |
-        echo "checking ref ${{ inputs.branch-tag-sha }}..."
-        ref="${{ inputs.branch-tag-sha }}"
-        refWithPrefix="refs/heads${{ steps.remove-ref-prefix.outputs.result }}"
+        echo "checking ref ${GITHUB_REF}..."
+        ref=${GITHUB_REF##*/}
+        refWithPrefix="refs/heads${ref}"
         
+        echo "::set-output name=REF_WITHOUT_PREFIX::${ref}"
         echo "::set-output name=REF_EXISTS::false"
         echo "::set-output name=REF_TYPE::unknown"
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,8 @@ runs:
     - id: remove-ref-prefix
       env: 
         GITHUB_REF: ${{ inputs.branch-tag-sha }}
-      run: echo "##[set-output name=result;]${GITHUB_REF##*/}"
+      run: echo "::set-output name=result::${GITHUB_REF##*/}"  
+      #run: echo "##[set-output name=result;]${GITHUB_REF##*/}"
       
     - id: determine-ref
       shell: bash


### PR DESCRIPTION
# Summary of PR changes
There are instances when the prefix is included on the input `branch-tag-sha`.  Parse out the prefix when determining if the tag/branch is valid.

Output parsed ref without prefix for reference outside of action.  As an example, creating a PR.

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
