### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: verify version exists before deploying
-        uses: im-open/verify-git-ref@v1.1.1
+        uses: im-open/verify-git-ref@v1.2.0
         with:
           branch-tag-sha: ${{ github.event.inputs.branch-tag-sha }}
 

--- a/action.yml
+++ b/action.yml
@@ -29,28 +29,28 @@ runs:
         ref="${{ inputs.branch-tag-sha }}"
         refWithPrefix="refs/heads${{ inputs.branch-tag-sha }}"
         
-        echo "::set-output name=REF_EXISTS::false"
-        echo "::set-output name=REF_TYPE::unknown"
+        echo "REF_EXISTS=false" >> $GITHUB_OUTPUT
+        echo "REF_TYPE=unknown" >> $GITHUB_OUTPUT
 
         if [ $(git tag -l "$ref") ]; then
           echo "The ref '${ref}' exists as a tag"
-          echo "::set-output name=REF_EXISTS::true"
-          echo "::set-output name=REF_TYPE::tag"
+          echo "REF_EXISTS=true" >> $GITHUB_OUTPUT
+          echo "REF_TYPE=tag" >> $GITHUB_OUTPUT
 
         elif [ "$(git show-ref -s "$ref")" ]; then
           echo "The ref '${ref}' exists as a branch (no prefix was added to the input)"
-          echo "::set-output name=REF_EXISTS::true"
-          echo "::set-output name=REF_TYPE::branch"
+          echo "REF_EXISTS=true" >> $GITHUB_OUTPUT
+          echo "REF_TYPE=branch" >> $GITHUB_OUTPUT
 
         elif [ "$(git show-ref -s "$refWithPrefix")" ]; then
           echo "The ref '${refWithPrefix}' exists as a branch (the refs/heads/ prefix was added to the input)"
-          echo "::set-output name=REF_EXISTS::true"
-          echo "::set-output name=REF_TYPE::branch"
+          echo "REF_EXISTS=true" >> $GITHUB_OUTPUT
+          echo "REF_TYPE=branch" >> $GITHUB_OUTPUT
 
         elif git cat-file -e $ref^{commit}; then
           echo "The ref '${ref}' exists as a SHA"
-          echo "::set-output name=REF_EXISTS::true"
-          echo "::set-output name=REF_TYPE::sha"
+          echo "REF_EXISTS=true" >> $GITHUB_OUTPUT
+          echo "REF_TYPE=sha" >> $GITHUB_OUTPUT
           
         else
           echo "The ref does not appear to exist"


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
